### PR TITLE
Cli flags support and kebab to snake and custom build flag

### DIFF
--- a/mage/main_test.go
+++ b/mage/main_test.go
@@ -1131,7 +1131,7 @@ func TestGoCmd(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := Compile("", "", dir, os.Args[0], name, []string{}, false, stderr, buf); err != nil {
+	if err := Compile("", "", "", dir, os.Args[0], name, []string{}, false, stderr, buf); err != nil {
 		t.Log("stderr: ", stderr.String())
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR is adding support for "-bflags" which is custom Go build flags used when you are building your custom tool made with mage.

This allows you to set some variables in your go project which are only known at compile time, like 
commit hash for example:

```
mage -compile -bflags "-ldflags=-X 'github.com/my-tool/mytool.commitHash=`git rev-parse HEAD`'"  ./tool
```
